### PR TITLE
fix: change data-base-target to "_next"

### DIFF
--- a/library/Feeds/Web/Table.php
+++ b/library/Feeds/Web/Table.php
@@ -87,7 +87,7 @@ class Table extends BaseHtmlElement
 
                 if ($link !== null) {
                     $text = new Link($text, $link, Attributes::create([
-                        'data-base-target' => '_self',
+                        'data-base-target' => '_next',
                     ]));
                 }
                 $rowElements[] = HtmlElement::create('td', null, $text);


### PR DESCRIPTION
This makes the page linked to open in the right column instead of the current page.

resolves #9