### PR TITLE
Limit image size

### DIFF
--- a/public/css/item.less
+++ b/public/css/item.less
@@ -47,6 +47,7 @@
     width: 100%;
     white-space: normal;
 
+    // This makes sure images don't overflow the view and also limits the image's height
     & img {
         max-width: 100%;
         max-height: 70vH;


### PR DESCRIPTION
Limit image size to 100% of the container width and at most 70% of the viewport height.

This makes sure images don't overflow the view and also limits the image's height when they are in vertical format.