### PR TITLE
Fix uninitialized value in ViewModeSwitcher

### DIFF
--- a/library/Feeds/Web/FeedViewModeSwitcher.php
+++ b/library/Feeds/Web/FeedViewModeSwitcher.php
@@ -34,7 +34,7 @@ class FeedViewModeSwitcher extends Form
         'common'   => 'default'
     ];
 
-    protected string $defaultViewMode;
+    protected string $defaultViewMode = self::DEFAULT_VIEW_MODE;
 
     /** @var string */
     protected $method = 'POST';
@@ -51,7 +51,7 @@ class FeedViewModeSwitcher extends Form
      */
     public function getDefaultViewMode(): string
     {
-        return $this->defaultViewMode ?: static::DEFAULT_VIEW_MODE;
+        return $this->defaultViewMode;
     }
 
     /**


### PR DESCRIPTION
Sometimes, not sure yet what the circumstances are, the ViewModeSwitcher throws this:

> Typed property Icinga\Module\Feeds\Web\FeedViewModeSwitcher::$defaultViewMode must not be accessed before initialization
> 
> #0 /usr/share/icingaweb2/modules/feeds/library/Feeds/Web/FeedViewModeSwitcher.php(102): Icinga\Module\Feeds\Web\FeedViewModeSwitcher->getDefaultViewMode()
> #1 /usr/share/icingaweb2/modules/feeds/library/Feeds/Controller/BaseController.php(218): Icinga\Module\Feeds\Web\FeedViewModeSwitcher->getViewMode()
> 