### PR TITLE
fix: disable image float in feed body

### DIFF
--- a/public/css/item.less
+++ b/public/css/item.less
@@ -63,7 +63,7 @@ item.less contains styles for the items in a feed
     & img {
         max-width: 100%;
         max-height: 70vH;
-
+        float: none;
     }
 
     & a {


### PR DESCRIPTION
This slightly improved the rendering of header images in the icinga blog.
It's still not ideal, but there is little I can do for malformed feed content.

Before:

<img width="2340" height="975" alt="Screenshot From 2025-10-13 09-32-36" src="https://github.com/user-attachments/assets/033b11ab-09a2-4a42-8083-58a83646b57d" />

After:

<img width="2337" height="1129" alt="image" src="https://github.com/user-attachments/assets/4abdc917-9d16-4fa7-9cf5-3f0169351770" />
