### PR TITLE
fix: explititly set image height to auto

### DIFF
--- a/public/css/item.less
+++ b/public/css/item.less
@@ -63,6 +63,7 @@ item.less contains styles for the items in a feed
     & img {
         max-width: 100%;
         max-height: 70vH;
+        height: auto;
         float: none;
     }
 


### PR DESCRIPTION
Sometimes images are set with an explicit height in the image tag.
This breaks our automatic image scaling.

Before:

<img width="640" height="1018" alt="image" src="https://github.com/user-attachments/assets/ab5928d5-7928-445d-bc48-5ebb8edea26d" />

After:

<img width="640" height="859" alt="Screenshot From 2025-10-13 10-06-15" src="https://github.com/user-attachments/assets/f37d883f-237d-4990-bbaa-1f3c1e60552d" />
