### PR TITLE
Fix missing item date and description

### DIFF
--- a/library/Feeds/Parser/Result/FeedItem.php
+++ b/library/Feeds/Parser/Result/FeedItem.php
@@ -12,7 +12,7 @@ class FeedItem
     public ?Feed $feed = null;
     public ?string $title = null;
     public ?string $link = null;
-    public ?string $description = null;
+    public string $description = '';
     public array $categories = [];
     public ?string $creator = null;
     public ?string $image = null;
@@ -20,8 +20,8 @@ class FeedItem
 
     public function compareDate(FeedItem $other): int
     {
-        $ad = $this->date ?? new DateTime('NOW');
-        $bd = $other->date ?? new DateTime('NOW');
+        $ad = $this->date ?? new DateTime('@0');
+        $bd = $other->date ?? new DateTime('@0');
 
         if ($ad == $bd) {
             return 0;

--- a/library/Feeds/Web/Item.php
+++ b/library/Feeds/Web/Item.php
@@ -103,7 +103,7 @@ class Item extends BaseHtmlElement
 
     protected function getContentElement(): ?BaseHtmlElement
     {
-        $text = $this->item->description;
+        $text = $this->item->description ?? '';
         $description = new FeedContent($text);
 
         return HtmlElement::create(
@@ -122,7 +122,10 @@ class Item extends BaseHtmlElement
 
     protected function getDate(): BaseHtmlElement
     {
-        return (new TimeAgo($this->item->date->getTimestamp()));
+        $d = $this->item->date;
+        $ts = $this->item->date !== null ? $this->item->date->getTimestamp() : 0;
+
+        return (new TimeAgo($ts));
     }
 
     protected function assembleHeader(): BaseHtmlElement


### PR DESCRIPTION
Some guardrails when there are invalid items in a feed.

I switched to `new DateTime('@0')` so that these elements are not shown on top.

Fixed #64 