### PR TITLE
Use Null coalescing operator instead of default value of `getPopulatedValue`

### DIFF
--- a/library/Feeds/Web/FeedViewModeSwitcher.php
+++ b/library/Feeds/Web/FeedViewModeSwitcher.php
@@ -99,7 +99,7 @@ class FeedViewModeSwitcher extends Form
      */
     public function getViewMode(): string
     {
-        $viewMode = $this->getPopulatedValue($this->getViewModeParam(), $this->getDefaultViewMode());
+        $viewMode = $this->getPopulatedValue($this->getViewModeParam()) ?? $this->getDefaultViewMode();
 
         if (array_key_exists($viewMode, static::$viewModes)) {
             return $viewMode;


### PR DESCRIPTION
Populated values gets populated with a null value if there is no user preference set.
The default parameter is only used if the value isn't populated at all.
A null value still counts as populated and is therefore returned by `getPopulatedValue`.

Calling `array_key_exists` with a null key is deprecated in PHP 8.5.