### PR TITLE
Add support for RSS1.0 feeds

### DIFF
--- a/application/forms/FeedForm.php
+++ b/application/forms/FeedForm.php
@@ -82,7 +82,8 @@ class FeedForm extends CompatForm
             ),
             'multiOptions' => [
                 'auto' => $this->translate('Determine automatically'),
-                'rss' => $this->translate('RSS'),
+                'rss' => $this->translate('RSS2.0'),
+                'rss1.0' => $this->translate('RSS1.0'),
                 'atom' => $this->translate('Atom'),
                 'jsonfeed' => $this->translate('JSONfeed'),
             ],

--- a/library/Feeds/FeedReader.php
+++ b/library/Feeds/FeedReader.php
@@ -6,6 +6,7 @@ use Icinga\Module\Feeds\Parser\AtomParser;
 use Icinga\Module\Feeds\Parser\FeedType;
 use Icinga\Module\Feeds\Parser\JsonfeedParser;
 use Icinga\Module\Feeds\Parser\RSSParser;
+use Icinga\Module\Feeds\Parser\RSS1Parser;
 use Icinga\Module\Feeds\Parser\Result\Feed;
 
 use Icinga\Application\Config;
@@ -78,7 +79,13 @@ class FeedReader
                 try {
                     return RSSParser::parse($rawResponse);
                 } catch (Exception $ex) {
-                    // Not an RSS feed
+                    // Not an RSS 2.0 feed
+                }
+
+                try {
+                    return RSS1Parser::parse($rawResponse);
+                } catch (Exception $ex) {
+                    // Not an RSS 1.0 feed
                 }
 
                 try {
@@ -96,6 +103,8 @@ class FeedReader
                 throw new Exception('Unsupported feed type or invalid data in feed');
             case FeedType::RSS:
                 return RSSParser::parse($rawResponse);
+            case FeedType::RSS1:
+                return RSS1Parser::parse($rawResponse);
             case FeedType::Atom:
                 return AtomParser::parse($rawResponse);
             case FeedType::Jsonfeed:

--- a/library/Feeds/Parser/FeedType.php
+++ b/library/Feeds/Parser/FeedType.php
@@ -13,6 +13,7 @@ enum FeedType: int
     case RSS = 1;
     case Atom = 2;
     case Jsonfeed = 3;
+    case RSS1 = 4;
 
     /**
      * display returns the string representation of the type
@@ -22,6 +23,7 @@ enum FeedType: int
         return match ($this) {
             self::Auto => 'auto',
             self::RSS => 'rss',
+            self::RSS1 => 'rss1.0',
             self::Atom => 'atom',
             self::Jsonfeed => 'jsonfeed',
             default => throw new Exception('Unreachable code')
@@ -36,6 +38,7 @@ enum FeedType: int
         return match ($display) {
             'auto' => self::Auto,
             'rss' => self::RSS,
+            'rss1.0' => self::RSS1,
             'atom' => self::Atom,
             'jsonfeed' => self::Jsonfeed,
             default => throw new Exception('Invalid FeedType')

--- a/library/Feeds/Parser/RSS1Parser.php
+++ b/library/Feeds/Parser/RSS1Parser.php
@@ -11,20 +11,21 @@ use DateTime;
 use DateTimeInterface;
 
 /**
- * RSSParser is used to parse RSS 2.0 feeds
+ * RSS1Parser is used to parse RSS 1.0 feeds
  */
-class RSSParser
+class RSS1Parser
 {
     /**
      * parse tries to parse the given string into a Feed object
      */
     public static function parse(string $raw): Feed
     {
-        // FIXME: This assumes that the string is valid xml
         $xmlElement = new SimpleXMLElement($raw);
+        $xmlElement->registerXPathNamespace('rss', 'http://purl.org/rss/1.0/');
+        $xmlElement->registerXPathNamespace('dc', 'http://purl.org/dc/elements/1.1/');
 
-        if ($xmlElement->getName() !== 'rss') {
-            throw new Exception('Invalid RSS2.0-Feed');
+        if ($xmlElement->getName() !== 'RDF') {
+            throw new Exception('Invalid RSS1.0-Feed');
         }
 
         $xmlElement->rewind();
@@ -55,11 +56,14 @@ class RSSParser
                         }
                     }
                     break;
-                case 'item':
-                    $item = static::parseItem($feed, $xmlItemElement);
-                    $feed->addItem($item);
-                    break;
             }
+        }
+
+        $items = $xml->xpath('//rss:item');
+
+        foreach ($items as $xmlItemElement) {
+            $item = static::parseItem($feed, $xmlItemElement);
+            $feed->addItem($item);
         }
 
         return $feed;
@@ -72,16 +76,18 @@ class RSSParser
             $dateStr,
         );
 
+        // <dc:date> should be ISO 8601: https://web.resource.org/rss/1.0/modules/dc/
         if ($datetime === false) {
             $datetime = DateTime::createFromFormat(
-                DateTimeInterface::RFC822,
+                DateTimeInterface::ISO8601,
                 $dateStr,
             );
         }
 
+        // We probably don't need this, but let's keep it just in case
         if ($datetime === false) {
             $datetime = DateTime::createFromFormat(
-                DateTimeInterface::RFC7231,
+                DateTimeInterface::RFC822,
                 $dateStr,
             );
         }
@@ -112,7 +118,6 @@ class RSSParser
 
     protected static function parseItem(Feed $feed, SimpleXMLElement $xml): FeedItem
     {
-        // TODO: Check if the element is of the right type
         $item = new FeedItem();
         $item->feed = $feed;
 
@@ -127,27 +132,15 @@ class RSSParser
                 case 'description':
                     $item->description = $xmlItemElement->__toString();
                     break;
-                case 'pubDate':
-                    $dateString = $xmlItemElement->__toString();
-                    $item->date = static::parseDateTime($dateString);
-                    break;
-                case 'category':
-                    $category = $xmlItemElement->__toString();
-                    $item->categories[] = $category;
-                    break;
-                case 'image':
-                    foreach ($xmlItemElement as $imgTagName => $imgElement) {
-                        if ($imgTagName === 'url') {
-                            $item->image = $imgElement->__toString();
-                            break;
-                        }
-                    }
-                    break;
             }
         }
 
         foreach ($xml->children('dc', true) as $elementName => $xmlItemElement) {
             switch ($elementName) {
+                case 'date':
+                    $dateString = $xmlItemElement->__toString();
+                    $item->date = static::parseDateTime($dateString);
+                    break;
                 case 'creator':
                     $item->creator = $xmlItemElement->__toString();
                     break;


### PR DESCRIPTION
We probably could have done this in the existing RSSParser file, avoiding duplication, however, this way we keep the indiviual parsers simpler.

See #77 