### PR TITLE
Add Csp hook

### DIFF
--- a/library/Feeds/ProvidedHook/Csp.php
+++ b/library/Feeds/ProvidedHook/Csp.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Icinga\Module\Feeds\ProvidedHook;
+
+use Icinga\Application\Hook\CspHook;
+use Icinga\Authentication\Auth;
+use Icinga\Module\Feeds\Storage\StorageFactory;
+use Icinga\User;
+use ipl\Web\Common\Csp as CspInstance;
+use ipl\Web\Url;
+
+/**
+ * Csp hook to add the feed images to the content security policy
+ *
+ * All users with the permission 'feeds/view' will get the CSP for all feeds.
+ * This hook assumes that images are sourced from the same domain as the feed.
+ */
+class Csp extends CspHook
+{
+    public function getCspForAllUsers(): CspInstance
+    {
+        $csp = new CspInstance();
+
+        $storage = StorageFactory::getStorage();
+        foreach ($storage->getFeeds() as $feed) {
+            $url = Url::fromPath($feed->url);
+            $csp->add('img-src', $url->getScheme() . '://' . $url->getHost());
+        }
+
+        return $csp;
+    }
+
+    public function getCspForUser(User $user): CspInstance
+    {
+        if (Auth::getInstance()->hasPermission('feeds/view')) {
+            return $this->getCspForAllUsers();
+        }
+
+        return new CspInstance();
+    }
+}

--- a/run.php
+++ b/run.php
@@ -1,1 +1,5 @@
 <?php
+
+use Icinga\Module\Feeds\ProvidedHook\Csp;
+
+Csp::register();


### PR DESCRIPTION
Register a `CspHook` implementation that allows the browser to load feed images by adding each configured feed's scheme and host to the `img-src` content security policy directive.

Access is gated behind the `feeds/view` permission: users without it receive no additional CSP directives.

**requires** icingaweb 2.14.0